### PR TITLE
Add flag to invalidate cache

### DIFF
--- a/gh/main.go
+++ b/gh/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // Gh is Github CLI module for Dagger

--- a/gh/main.go
+++ b/gh/main.go
@@ -23,7 +23,7 @@ func (m *Gh) Run(
 	// disable cache
 	// +optional
 	// +default=false
-	disableCache bool
+	disableCache bool,
 ) (string, error) {
 	file := m.Get(ctx, version)
 

--- a/gh/main.go
+++ b/gh/main.go
@@ -20,14 +20,23 @@ func (m *Gh) Run(
 	// +optional
 	// +default="2.37.0"
 	version string,
+	// disable cache
+	// +optional
+	// +default=false
+	disableCache bool
 ) (string, error) {
 	file := m.Get(ctx, version)
 
-	return dag.Container().
+	ctr := dag.Container().
 		From("alpine/git:latest").
 		WithFile("/usr/local/bin/gh", file).
-		WithSecretVariable("GITHUB_TOKEN", token).
-		WithExec([]string{"sh", "-c", strings.Join([]string{"/usr/local/bin/gh", cmd}, " ")}, ContainerWithExecOpts{SkipEntrypoint: true}).
+		WithSecretVariable("GITHUB_TOKEN", token)
+	
+	if (disableCache) {
+		ctr = ctr.WithEnvVariable("CACHEBUSTER", time.Now().String())
+	}
+
+	return ctr.WithExec([]string{"sh", "-c", strings.Join([]string{"/usr/local/bin/gh", cmd}, " ")}, ContainerWithExecOpts{SkipEntrypoint: true}).
 		Stdout(ctx)
 }
 


### PR DESCRIPTION
When using the same cmd more than once it may get cached even if the result of the command may return a different result (e.g. listing pull requests on a repository)