### PR TITLE
refactor(k3s): remove specific address binding from k3s server

### DIFF
--- a/k3s/main.go
+++ b/k3s/main.go
@@ -108,7 +108,6 @@ func (m *K3S) k3sServer(ctr *Container) *Container {
 	// k3s server -- options
 	opts := []string{"k3s", "server"}
 
-	opts = append(opts, "--bind-address", "$(ip route | grep src | awk '{print $NF}')")
 	opts = append(opts, "--https-listen-port", fmt.Sprintf("%d", m.HttpListenPort))
 	opts = append(opts, "--disable", "traefik")
 	opts = append(opts, "--disable", "metrics-server")


### PR DESCRIPTION
The default binding `0.0.0.0` is a better option for handling operations instead of binding only internal addresses. If needed we can make it configurable in the future